### PR TITLE
Update CachedAsyncImage.swift

### DIFF
--- a/Sources/CachedAsyncImage/CachedAsyncImage.swift
+++ b/Sources/CachedAsyncImage/CachedAsyncImage.swift
@@ -37,6 +37,20 @@ public struct CachedAsyncImage<Content: View>: View {
         Group {
             if let image = image {
                 content(image)
+            } else if let url = url {
+                let request = URLRequest(url: url)
+                if let cachedResponse = URLCache.shared.cachedResponse(for: request),
+                    let cachedImage = UIImage(data: cachedResponse.data)
+                {
+                    content(Image(uiImage: cachedImage))
+                } else {
+                    placeholder()
+                        .onAppear {
+                            Task {
+                                await loadImage()
+                            }
+                        }
+                }
             } else {
                 placeholder()
                     .onAppear {

--- a/Sources/CachedAsyncImage/CachedAsyncImage.swift
+++ b/Sources/CachedAsyncImage/CachedAsyncImage.swift
@@ -1,26 +1,50 @@
 import SwiftUI
 
-public struct CachedAsyncImage: View {
+public struct CachedAsyncImage<Content: View>: View {
     private let url: URL?
     @State private var image: Image? = nil
     @State private var isLoading = false
+    private let content: (Image) -> Content
+    private let placeholder: () -> Content
 
-    public init(url: URL?) {
+    public init<I: View, P: View>(
+        url: URL?, @ViewBuilder content: @escaping (Image) -> I, @ViewBuilder placeholder: @escaping () -> P
+    ) where Content == AnyView {
         self.url = url
+        self.content = { image in AnyView(content(image)) }
+        self.placeholder = { AnyView(placeholder()) }
+    }
+
+    public init(url: URL?) where Content == AnyView {
+        self.url = url
+        self.content = { image in AnyView(image) }
+        self.placeholder = { AnyView(ProgressView()) }
+    }
+
+    public init(url: URL?, scale: CGFloat = 1.0) where Content == AnyView {
+        self.url = url
+        self.content = { image in AnyView(image.resizable().scaledToFit()) }
+        self.placeholder = { AnyView(ProgressView()) }
+    }
+
+    public init<I: View>(url: URL?, @ViewBuilder content: @escaping (Image) -> I) where Content == AnyView {
+        self.url = url
+        self.content = { image in AnyView(content(image)) }
+        self.placeholder = { AnyView(ProgressView()) }
     }
 
     public var body: some View {
-        if let image = image {
-            image
-                .resizable()
-                .scaledToFit()
-        } else {
-            ProgressView()
-                .onAppear {
-                    Task {
-                        await loadImage()
+        Group {
+            if let image = image {
+                content(image)
+            } else {
+                placeholder()
+                    .onAppear {
+                        Task {
+                            await loadImage()
+                        }
                     }
-                }
+            }
         }
     }
 
@@ -33,7 +57,8 @@ public struct CachedAsyncImage: View {
         // Check if the image is already cached
         let request = URLRequest(url: url)
         if let cachedResponse = URLCache.shared.cachedResponse(for: request),
-           let cachedImage = UIImage(data: cachedResponse.data) {
+            let cachedImage = UIImage(data: cachedResponse.data)
+        {
             await MainActor.run {
                 self.image = Image(uiImage: cachedImage)
                 self.isLoading = false


### PR DESCRIPTION
Make it feel more like AsyncImage. So you can use this package as below:
```Swift
AsyncImage(url: data.imgUrl) { image in
    image
        .resizable()
        .aspectRatio(contentMode: .fill)
        .frame(width: width, height: height, alignment: .top)
        .clipped()
} placeholder: {
    ProgressView()
        .frame(maxWidth: .infinity)
}

CachedAsyncImage(url: data.imgUrl) { image in
    image
        .resizable()
        .aspectRatio(contentMode: .fill)
        .frame(width: width, height: height, alignment: .top)
        .clipped()
} placeholder: {
    ProgressView()
        .frame(maxWidth: .infinity)
}
```

More information from Copilot:

This pull request enhances the `CachedAsyncImage` component by introducing more flexibility in how content and placeholders are rendered, along with a minor formatting improvement in the image caching logic. The most important changes are the addition of multiple initializers to support custom views and the refactoring of the `body` property to use a `Group` for better readability.

### Enhancements to `CachedAsyncImage`:

* **Support for Custom Content and Placeholders**:
  - Added generic type `Content` to allow custom views for both the loaded image and the placeholder.
  - Introduced multiple initializers to support different use cases, such as default rendering, custom content, and custom placeholders. (`[Sources/CachedAsyncImage/CachedAsyncImage.swiftL3-R49](diffhunk://#diff-5ea153af125f949ea519935b06f95c17f818e3a515a13713fdb2aca2a9654c8bL3-R49)`)

* **Refactored `body` Property**:
  - Updated the `body` to use a `Group` for better readability and to integrate the new `content` and `placeholder` closures for rendering. (`[Sources/CachedAsyncImage/CachedAsyncImage.swiftL3-R49](diffhunk://#diff-5ea153af125f949ea519935b06f95c17f818e3a515a13713fdb2aca2a9654c8bL3-R49)`)

### Code Quality Improvements:

* **Formatting in Image Caching Logic**:
  - Adjusted the formatting of the `if` statement in the image caching logic for improved readability. (`[Sources/CachedAsyncImage/CachedAsyncImage.swiftL36-R61](diffhunk://#diff-5ea153af125f949ea519935b06f95c17f818e3a515a13713fdb2aca2a9654c8bL36-R61)`)